### PR TITLE
added sessions for sending request to reuse ports

### DIFF
--- a/benchmarking/apis.py
+++ b/benchmarking/apis.py
@@ -29,27 +29,27 @@ MOBILE_NUMBER_LENGTH = int(user_constants['MOBILE_NUMBER_LENGTH'])
 EMAIL_DOMAIN = user_constants['EMAIL_DOMAIN']
 
 
-def login_request(username, password):
-    return requests.post(BASE_URL + 'login',
-                         json={
-                             "Username": username,
-                             "Password": password,
-                         })
-
-
-def view_user_request(username):
-    return requests.get(BASE_URL + 'viewUser',
-                        params={
-                            "username": username,
+def login_request(session, username, password):
+    return session.post(BASE_URL + 'login',
+                        json={
+                            "Username": username,
+                            "Password": password,
                         })
 
 
-def list_chats_request(user_id):
-    return requests.get(BASE_URL + 'users/' + str(user_id) + '/chats')
+def view_user_request(session, username):
+    return session.get(BASE_URL + 'viewUser',
+                       params={
+                           "username": username,
+                       })
 
 
-def list_messages_request(user_id, chat_id):
-    return requests.get(
+def list_chats_request(session, user_id):
+    return session.get(BASE_URL + 'users/' + str(user_id) + '/chats')
+
+
+def list_messages_request(session, user_id, chat_id):
+    return session.get(
         BASE_URL +
         'users/' +
         str(user_id) +
@@ -59,27 +59,27 @@ def list_messages_request(user_id, chat_id):
     )
 
 
-def create_chat_request(user_id, username):
-    return requests.post(BASE_URL + 'users/' + str(user_id) + '/chats',
-                         json={"username": username})
+def create_chat_request(session, user_id, username):
+    return session.post(BASE_URL + 'users/' + str(user_id) + '/chats',
+                        json={"username": username})
 
 
-def create_message_request(user_id, chat_id):
-    return requests.post(BASE_URL + 'users/' + str(user_id) + '/chats/' + str(chat_id) + '/messages',
-                         params={
-                             "textContent": "Hello friend",
-                         })
+def create_message_request(session, user_id, chat_id):
+    return session.post(BASE_URL + 'users/' + str(user_id) + '/chats/' + str(chat_id) + '/messages',
+                        params={
+                            "textContent": "Hello friend",
+                        })
 
 
-def signup_request():
+def signup_request(session):
     username = random_string.alpha_numeric_variable_length(USERNAME_MIN_LENGTH, USERNAME_MAX_LENGTH)
     email = username + EMAIL_DOMAIN
     mobile_no = random_string.numeric_fixed_length(MOBILE_NUMBER_LENGTH)
     password = random_string.alpha_numeric_fixed_length(PASSWORD_LENGTH)
-    return requests.post(SIGNUP_URL,
-                         json={
-                             "Username": username,
-                             "EmailID": email,
-                             "MobileNo": mobile_no,
-                             "Password": password,
-                         })
+    return session.post(SIGNUP_URL,
+                        json={
+                            "Username": username,
+                            "EmailID": email,
+                            "MobileNo": mobile_no,
+                            "Password": password,
+                        })

--- a/benchmarking/users.py
+++ b/benchmarking/users.py
@@ -5,6 +5,9 @@ MultiUser and SignUpUser classes override User's simulate method,
 that sends requests and returns a list of tuple (response object, current_total_qps).
 """
 from datetime import datetime
+
+import requests
+
 import apis
 import random
 import time
@@ -80,23 +83,24 @@ class MultiUser(User):
         Repeats the above steps until end_time.
         Returns a list of tuple (api_name, response object, current_total_qps).
         """
+        session = requests.Session()
         response_list = []
         while datetime.now() < User.end_time:
             api_number = random.choices(range(1, 7), MultiUser.distribution)[0]
             if api_number == 1:
-                response = apis.login_request(self.username, self.password)
+                response = apis.login_request(session, self.username, self.password)
             elif api_number == 2:
-                response = apis.view_user_request(get_random_username())
+                response = apis.view_user_request(session, get_random_username())
             elif api_number == 3:
-                response = apis.list_chats_request(self.user_id)
+                response = apis.list_chats_request(session, self.user_id)
             elif api_number == 4:
                 index = random.randint(0, 1)
-                response = apis.list_messages_request(self.user_id, self.chat_id_list[index])
+                response = apis.list_messages_request(session, self.user_id, self.chat_id_list[index])
             elif api_number == 5:
-                response = apis.create_chat_request(self.user_id, get_random_username())
+                response = apis.create_chat_request(session, self.user_id, get_random_username())
             else:
                 index = random.randint(0, 1)
-                response = apis.create_message_request(self.user_id, self.chat_id_list[index])
+                response = apis.create_message_request(session, self.user_id, self.chat_id_list[index])
             response_list.append((MultiUser.api_names[api_number - 1], response, User.total_qps))
             time.sleep(User.interval)
         return response_list
@@ -110,8 +114,9 @@ class SignupUser(User):
         Repeats until end_time.
         Returns a list of tuple (api_name, response object, current_total_qps).
         """
+        session = requests.Session()
         response_list = []
         while datetime.now() < User.end_time:
-            response_list.append(("signup", apis.signup_request(), User.total_qps))
+            response_list.append(("signup", apis.signup_request(session), User.total_qps))
             time.sleep(User.interval)
         return response_list

--- a/src/main/appengine/app.yaml
+++ b/src/main/appengine/app.yaml
@@ -1,5 +1,5 @@
 runtime: java11
-instance_class: F1
+instance_class: F2
 
 # Explicitly set the memory limit and maximum heap size for the Spring Boot app
 env_variables:


### PR DESCRIPTION
1. Since there are limited number of ports (65535), we will have to reuse the ports while sending requests. With this fix, each User instance creates a session and uses it for sending requests, hence a user instance uses the same port number for sending each request.
2. With the current configuration of app engine, we are getting memory limit exceeded error on server for some requests. With this fix, we are changing the instance class for app engine from F1 to F2 (F2 has memory limit of 512MB).
 